### PR TITLE
Fixed locale names on localeData.json

### DIFF
--- a/localeData.json
+++ b/localeData.json
@@ -1273,7 +1273,7 @@
     "bcp47": "es"
   },
   "es_PE": {
-    "englishName": "Spanish (Peru",
+    "englishName": "Spanish (Peru)",
     "localizedName": "español (Perú)",
     "direction": "ltr",
     "fallbackLocales": [
@@ -2023,7 +2023,7 @@
   },
   "it_CH": {
     "englishName": "Italian (Switzerland)",
-    "localizedName": "italiano(Svizzera)",
+    "localizedName": "italiano (Svizzera)",
     "direction": "ltr",
     "fallbackLocales": [
       "it"


### PR DESCRIPTION
Hi. I've made a few changes to localeData.json that I have forgot. I have some locale names of Spanish (Peru) and Italian (Switzerland) (italiano (Svizzera)) fixed, with correct placement of parentheses. I'd like you to merge this PR as soon as possible, to have consistency among localized locale names. Thank you.

PS: Also, thank you for your help in https://github.com/phetsims/babel/issues/31. It was helpful, but I couldn't see the difference now. The locale names seem to be unchanged as of now. I guess it's because of the caching problem of the website I was told on email. Anyway, I hope for the changes to happen, though late, and everything will be sorted.